### PR TITLE
Fix/style

### DIFF
--- a/account/admin.py
+++ b/account/admin.py
@@ -4,7 +4,10 @@ from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
 
 from .forms import UserChangeForm, UserCreationForm
 from .models import User
-
+import logging
+log = logging.getLogger(__name__)
+# convert the errors to text
+from django.utils.encoding import force_text
 
 class UserAdmin(BaseUserAdmin):
     form = UserChangeForm
@@ -13,7 +16,7 @@ class UserAdmin(BaseUserAdmin):
     list_display = ('email','nickname', 'petname', 'petkind', 'is_admin', 'profile')
     list_filter = ('is_admin',)
     fieldsets = (
-        (None, {'fields': ('email', 'password', 'passwordLength')}),
+        (None, {'fields': ('email', 'password1', 'password2',)}),
         ('Personal info', {'fields': ('nickname', 'petname', 'petkind','profile')}),
         ('Permissions', {'fields': ('is_admin',)}),
     )
@@ -27,7 +30,9 @@ class UserAdmin(BaseUserAdmin):
     search_fields = ('email',)
     ordering = ('email',)
     filter_horizontal = ()
-
+    def is_valid(self):
+        log.info(force_text(self.errors))
+        return super(UserAdmin, self).is_valid()
 
 admin.site.register(User, UserAdmin)
 admin.site.unregister(Group)

--- a/account/forms.py
+++ b/account/forms.py
@@ -109,10 +109,6 @@ class UserCreationForm(forms.ModelForm):
 
 
 class UserChangeForm(forms.ModelForm):
-    class Meta:
-        model = User
-        fields = '__all__'
-        fields = ('profile', 'nickname', 'password', 'password2', 'petkind', 'petname')
 
     email = forms.EmailField(
         label='',
@@ -181,6 +177,7 @@ class UserChangeForm(forms.ModelForm):
     class Meta:
         model = get_user_model()
         fields = ('email', 'profile', 'nickname', 'password1', 'password2', 'petkind', 'petname')
+
     def clean_nickname(self):
         nickname = self.cleaned_data.get("nickname")
         email=self.cleaned_data.get("email")
@@ -204,6 +201,7 @@ class UserChangeForm(forms.ModelForm):
         user.passwordLength = len(self.cleaned_data["password1"])
         if commit:
             user.save()
+            print('change form save')
         return user
 
 class LoginForm(forms.Form):

--- a/mypage/views.py
+++ b/mypage/views.py
@@ -77,15 +77,8 @@ def update_myInfo(request):
     if request.method == "POST":
         form = UserChangeForm(request.POST, request.FILES, instance=request.user)
         if form.is_valid():
-            # user = form.save(coomit=False)
             form.save()
-            print('now media')
-            print(request.user.profile)
-            # user.profile = request.POST.get('profile')
-            # user.save()
             return redirect('account:login')
     else:
         form = UserChangeForm(instance = request.user)
-        print('current media')
-        print(request.user.profile)
     return render(request, 'mypage/update_myInfo.html', {'form': form})

--- a/static/css/mypage/mypage.css
+++ b/static/css/mypage/mypage.css
@@ -182,7 +182,6 @@ button:focus {
 /* detail_myInfo */
 .myInfoBox {
     width: 100%;
-    ;
     margin: 90px auto 0;
     display: flex;
     flex-direction: column;

--- a/static/css/mypage/mypage.css
+++ b/static/css/mypage/mypage.css
@@ -6,6 +6,7 @@
     z-index: 1;
     padding: 0 145px;
 }
+
 button,
 button:focus {
     outline: none;
@@ -177,9 +178,11 @@ button:focus {
 .createButton:hover {
     color: #FFFFFF;
 }
+
 /* detail_myInfo */
 .myInfoBox {
-    width: 100%;;
+    width: 100%;
+    ;
     margin: 90px auto 0;
     display: flex;
     flex-direction: column;
@@ -187,25 +190,28 @@ button:focus {
     align-items: center;
     overflow: hidden;
 }
+
 .myInfoBox .fieldName {
     width: 95px;
-font-family: Noto Sans;
-font-weight: 600;
-font-size: 15px;
-line-height: 20px;
-color: #ABABAB;
-display: inline-block;
+    font-family: Noto Sans;
+    font-weight: 600;
+    font-size: 15px;
+    line-height: 20px;
+    color: #ABABAB;
+    display: inline-block;
 }
+
 .myInfoBox .fieldContent {
-font-family: Noto Sans;
-font-weight: 600;
-font-size: 15px;
-line-height: 20px;
-color: #575757;
-margin-left: 51px;
-display: inline-block;
-margin-bottom: 55px;
+    font-family: Noto Sans;
+    font-weight: 600;
+    font-size: 15px;
+    line-height: 20px;
+    color: #575757;
+    margin-left: 51px;
+    display: inline-block;
+    margin-bottom: 55px;
 }
+
 .userInfoBox {
     width: 665px;
     padding: 138px 0 135px;
@@ -214,6 +220,7 @@ margin-bottom: 55px;
     align-items: flex-start;
     flex-direction: column;
 }
+
 .petInfoBox {
     width: 665px;
     display: flex;
@@ -221,24 +228,26 @@ margin-bottom: 55px;
     align-items: flex-start;
     flex-direction: column;
 }
+
 .infoEditButton {
-min-width: 329px;
-width: 329px;
-height: 55px;
-background: #FF5C00;
-box-shadow: 6px 6px 30px rgba(255, 92, 0, 0.1);
-border-radius: 18px;
-font-family: Noto Sans;
-font-weight: 600;
-font-size: 18px;
-line-height: 25px;
-display: flex;
-justify-content: center;
-align-items: center;
-color: #FFFFFF;
-overflow: hidden;
-margin: 0 10px;
+    min-width: 329px;
+    width: 329px;
+    height: 55px;
+    background: #FF5C00;
+    box-shadow: 6px 6px 30px rgba(255, 92, 0, 0.1);
+    border-radius: 18px;
+    font-family: Noto Sans;
+    font-weight: 600;
+    font-size: 18px;
+    line-height: 25px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    color: #FFFFFF;
+    overflow: hidden;
+    margin: 0 10px;
 }
+
 .infoCancelButton {
     min-width: 329px;
     width: 329px;
@@ -256,14 +265,17 @@ margin: 0 10px;
     color: #575757;
     margin: 0 10px;
 }
+
 .infoEditButton:hover {
     color: #FFFFFF;
     background: #f35c05;
 }
+
 .infoCancelButton:hover {
     color: #575757;
     background: #f7f6f6;
 }
+
 .infoButtonBox {
     display: flex;
     padding-bottom: 270px;

--- a/templates/mypage/update_myInfo.html
+++ b/templates/mypage/update_myInfo.html
@@ -15,10 +15,10 @@
                     <img id="profileImage" src="{{MEDIA_URL}}{{user.profile}}" alt="profile image"/>
                     <input type="file" name="profile" accept="image/*" id="id_profile">
                     <label class="uploadButton" for="id_profile">이미지 업로드</label>
-                    <a href="#" class="deleteButton">삭제</a>
+                    <!-- <a href="#" class="deleteButton">삭제</a> -->
                 </div>
 
-                <div class="formField" {% if form.email.errors %} style="border: 2px solid #FF5C00;" {% endif %}>
+                <div class="formField" style="margin-bottom: 50px;">
                     <p class="registerInput">{{user.email}} (변경불가)</p>
                 </div>
                 <input type="email" name="email" class="registerInput" value="{{user.email}}" style="display: none;">
@@ -55,7 +55,7 @@
                     {% endif %}
                 </div>
 
-                <div class="formField" style="margin: 30px 0;">
+                <div class="formField" style="margin: 80px 0 33px;">
                     <select required name="petkind" class="registerInput" maxlength="4" id="id_petkind" required>
                         <option value="" disabled selected hidden>반려동물을 선택해주세요</option>
                         <option value="DOG">개</option>
@@ -96,22 +96,22 @@ $(document).ready(function(){
         console.log($("#id_profile"))
     });
     // 이미지 삭제
-    function resetInputFile($input, $profileImage) {
-        var agent = navigator.userAgent.toLowerCase();
-        if((navigator.appName == 'Netscape' && navigator.userAgent.search('Trident') != -1) || (agent.indexOf("msie") != -1)) {
-            // ie
-            $input.replaceWith($input.clone(true));
-            console.log('reset func execute ie')
-            console.log($input)
-            $('#profileImage').prop('src', '{% static "img/account/defaultProfile.png" %}');
-        } else {
-            //other
-            $input.val("");
-            console.log('reset func execute not ie')
-            console.log($input)
-            $('#profileImage').prop('src', '{% static "img/account/defaultProfile.png" %}');
-        }
-    }
+    // function resetInputFile($input, $profileImage) {
+    //     var agent = navigator.userAgent.toLowerCase();
+    //     if((navigator.appName == 'Netscape' && navigator.userAgent.search('Trident') != -1) || (agent.indexOf("msie") != -1)) {
+    //         // ie
+    //         $input.replaceWith($input.clone(true));
+    //         console.log('reset func execute ie')
+    //         console.log($input)
+    //         $('#profileImage').prop('src', '{% static "img/account/defaultProfile.png" %}');
+    //     } else {
+    //         //other
+    //         $input.val("");
+    //         console.log('reset func execute not ie')
+    //         console.log($input)
+    //         $('#profileImage').prop('src', '{% static "img/account/defaultProfile.png" %}');
+    //     }
+    // }
     $(".deleteButton").click(function(event) {
         let $input = $("#id_profile")
         let $profileImage = $("#profileImage")


### PR DESCRIPTION
## 개요
- 아까 급하게 보낸 유저 정보 수정의 css 완성 및 어드민 페이지에서 form 에러 수정

## 작업내용
- 유저 정보 수정폼에서 프로필 이미지의 인풋값을 없이 보내도(네트워크 패킷 확인했습니다.) 이전에 저장된 프로필 이미지가 <br>DB에서 삭제되지 않자 그게 디폴트 사진으로 저장되는 것 같습니다. 프론트엔드에서 빈 파일을 보내도 백엔드에선 프로필 이미지가 직전에 프로필로 지정했던 사진으로 저장되더라구요... 그것 때문에 오늘 하루종일 고생하다가ㅠㅠㅠㅠ 미디어 폴더에 잘못 손댔는지 전체가 다 삭제되고... 그 전까지는 프로필을 기본이미지로 다시 바꾸는 것만 빼고 완전 잘 되었는데 이후로는 계속 form이 저장이 안되거나 미디어 폴더가 이상해서.. 아주 힘들었습니다.... <br> 다행히 아까 PR을 pull하고 좀 더 헤맨 이후엔 다시 잘 되네요.. 한동안 다시 만든 media 폴더에 업로드가 안 되는 아찔한 상황이었습니다..ㅎㅎㅠㅠㅠ 완전 좌절...
<s>- 실제 구동 화면 쪽에서 UserChangeForm은 잘 작동하는데 아까 문제의 그 상황을 겪고나니 admin 페이지에서는 유저 정보 수정이 잘 안되는 것 같습니다. 음...제가 그 전에 확인해본 기억이 잘 안나서 확실히 그 문제 때문인지는 모르겠네요..
- 아무튼 실제 구동 화면에서는 잘 작동합니다. </s>
- 와 방금 어드민에서 수정 안되던 오류 고쳤습니다!! ㅠㅠㅠ admin.py에서 UserChangeForm 로직에 필요한 필드를 모두 주지않아서 모든 필드를 줬던 실제 구동화면과 달리 에러가 났던 거였습니다. 이미지 파일만 리셋되길래 이미지 쪽에 문제가 있는가 했는데 아니네요.. 지우님도 혹시 그런 경우가 있다면 다른 에러일 가능성도 꼭 생각해보시길 바랍니다. 이제 어드민 페이지, 실제 구동화면 모두 다 정상 작동합니다!
- 정보 수정 시 닉네임은 해당 유저의 기존 닉네임이거나 다른 유저의 닉네임과 겹치면 안된다는 두 조건을 만족시키기 위해 필터를 사용했습니다. accont/forms.py의 UserChangeForm을 확인하시면 됩니다.
- 일단 기본이미지로 다시 변경하는 건 시간이 더 필요할 것 같아 이미지 삭제 버튼을 주석 처리해두었습니다😥

## 리뷰어가 확인할 사항
- 유저 정보 디테일에서 비밀번호 갯수만큼 *을 찍기 위해 새로운 필드를 만들었으니 migrate 부탁드립니다. *을 보고싶다면 유저 정보 수정을 한번 하시면 업데이트될 겁니다. (테스트도 겸사겸사 부탁드립니다. 🙇‍♀️)

## 기타
- 이렇게 이상한 PR을 보내서 죄송합니다ㅠㅠ <br>혹시 로직의 궁금한 점이나 확인하고 싶으신 게 있다면 머지된 이전 PR을 확인해주세요! ㅠㅠㅠㅠㅠ  
