### PR TITLE
Fix hot recipe, best review error. Fix about, home css

### DIFF
--- a/.static_root/css/about/about.css
+++ b/.static_root/css/about/about.css
@@ -97,7 +97,7 @@
     box-shadow: 6px 6px 30px rgba(235, 55, 0, 0.1);
 }
 .row1 {
-    padding: 78px 64px 70px;
+    padding: 78px 120px 70px;
     font-family: Noto Sans;
     font-weight: 600;
     font-size: 18px;

--- a/home/views.py
+++ b/home/views.py
@@ -3,11 +3,11 @@ from django.core.paginator import Paginator
 from question.models import Question, Answer
 from recipe.models import Recipe_Img, Recipe
 from review.models import Review, Review_Img
-
+from django.db.models import Count
 
 def home(request):
     if request.method == 'GET':
-        hot_recipes = Recipe.objects.all().order_by('-like')
+        hot_recipes = Recipe.objects.all().annotate(num_like=Count('like')).order_by('-num_like')
         img = Recipe_Img.objects.all()
         hot_recipes_dict = {}
 
@@ -24,7 +24,7 @@ def home(request):
                 else:
                     hot_recipes_dict[temp] = ""
 
-        best_review = Review.objects.all().order_by('-like')
+        best_review = Review.objects.all().annotate(num_like=Count('like')).order_by('-num_like')
         img2 = Review_Img.objects.all()
         best_review_dict = {}
 

--- a/recipe/views.py
+++ b/recipe/views.py
@@ -66,7 +66,7 @@ def recipe_list(request):  # 카테고리, 지역에 따라 list가 다릅니다
     order = request.GET.get('order', 'recent')
     img = Recipe_Img.objects.all()
     recipes_dict={}
-    hot_recipes = Recipe.objects.all().order_by('-like')
+    hot_recipes = Recipe.objects.all().annotate(num_like=Count('like')).order_by('-num_like')
     hot_recipes_dict={}
     
     # 검색

--- a/review/views.py
+++ b/review/views.py
@@ -24,7 +24,7 @@ def review_list(request):
     img = Review_Img.objects.all()
     recipe = Recipe.objects.all()
     review_dict={}
-    best_review = Review.objects.all().order_by('-like')
+    best_review = Review.objects.all().annotate(num_like=Count('like')).order_by('-num_like')
     best_review_dict = {}
 
     if best_review.__len__() >= 4:

--- a/templates/about/about.html
+++ b/templates/about/about.html
@@ -50,7 +50,7 @@
                     <h4 style="color: #FF9900;">냥냥</h4>
                     <p>_<br>
                         Pet Friends의 리더<br>
-                        <span style="color:#575757;">
+                        <span style="color:#575757;word-break:keep-all;">
                             책임감이 강하다. 가끔 생각지도 못한 돌발 행동을 하기도 하지만,<br>
                             특유의 귀여움으로 위기모면 한다.
                         </span></p>
@@ -64,8 +64,8 @@
                     <h4 style="color: #F84B01;">총총</h4>
                     <p>_<br>
                     냥냥의 왼팔<br>
-                    <span style="color:#575757;">
-                        발이 빨라 해야할 일을 모든 빠르게 해낸다. 평소엔 카리스마<br>
+                    <span style="color:#575757;word-break:keep-all;">
+                        발이 빨라 해야할 일을 모든 빠르게 해낸다.<br>평소엔 카리스마 
                         넘치지만 밥먹을 때만큼은 귀엽고 진지하다.
                     </span></p>
                 </div>
@@ -76,8 +76,8 @@
                     <h4 style="color: #8D8D8D;">댕</h4>
                     <p> _<br>
                         냥냥의 오른팔<br>
-                        <span style="color:#575757;">
-                            큰 목소리와 용감함으로 팀을 경호한다. 사교성이 좋아서 팀원들과<br>
+                        <span style="color:#575757;word-break:keep-all;">
+                            큰 목소리와 용감함으로 팀을 경호한다.<br>사교성이 좋아서 팀원들과
                             모두 잘 지내고, 감정표현을 잘한다.
                         </span></p>
                 </div>
@@ -90,9 +90,9 @@
                     <h4 style="color: #373737;">잭</h4>
                     <p>_<br>
                         Pet Friends의 브레인<br>
-                        <span style="color:#575757;">
-                            예민한 청각과 시각으로 팀을 잘 이끌어 낸다.<br>
-                            게다가 머리도 좋아서 상황판단 능력이 대단하다.<br>
+                        <span style="color:#575757;word-break:keep-all;">
+                            예민한 청각과 시각으로 팀을 잘 이끌어 낸다.
+                            게다가 머리도 좋아서 상황판단 능력이 대단하다.
                             잭의 말이라면 모두가 잘 듣는다고 한다.
                         </span></p>
                 </div>
@@ -103,9 +103,9 @@
                     <h4 style="color: #CD8B40;">지지</h4>
                     <p>_<br>
                         귀여움의 끝판왕<br>
-                        <span style="color:#575757;">
-                            지지의 타고난 귀여움은 모두의 마음을 사르르<br>
-                            녹인다. 식탐이 많아서 제일 먼저 식사를 끝내고<br>
+                        <span style="color:#575757;word-break:keep-all;">
+                            지지의 타고난 귀여움은 모두의 마음을 사르르
+                            녹인다. 식탐이 많아서 제일 먼저 식사를 끝내고
                             음식을 숨겨 혼자 먹기도 한다.
                         </span></p>
                 </div>
@@ -116,10 +116,9 @@
                     <h4 style="color: #F97808;">무무</h4>
                     <p>_<br>
                         Pet Friends의 물담당<br>
-                        <span style="color:#575757;">
-                            타고난 헤엄실력으로 갑작스러운 수변이 일어나도<br>
-                            무무가 함께라면 모두 이겨낼 수 있다.무무의<br>
-                            작고 귀여운 헤엄은 모두가 놀랄 정도이다.
+                        <span style="color:#575757;word-break:keep-all;"></span>
+                            갑작스러운 수변이 일어나도 타고난 헤엄실력의 무무가 함께라면 모두 이겨낼 수 있다.
+                            무무의 작고 귀여운 헤엄은 모두가 놀랄 정도이다.
                         </span></p>
                 </div>
             </div>

--- a/templates/about/about.html
+++ b/templates/about/about.html
@@ -21,11 +21,11 @@
     <div class="Title">
         <h2 class="MainTitle">BI</h2>
         <p class="subTitle">_<br>
-        Brand Story</p>
+        Brand Identity</p>
     </div>
 </div>
 <div class="content" style="width:100%;">
-    <img id="BIImg" src="{% static 'img/about/BI.png' %}">
+    <img id="BIImg" style="width: 80%;text-align: center;" src="{% static 'img/about/BI.png' %}">
 </div>
 <div id="characterBox" style="margin-top:100px;">
     <div class="Title">
@@ -40,7 +40,7 @@
             행동을 보고 용기를 얻은 댕, 지지, 잭, 총총, 무무 가 힘을 합치기로 했답니다!<br>
             이렇게 탄생하게 된 Pet Friends를 위해 다양한 음식들을 공유하고 알아볼까요?
         </p>
-        <img id="characterImg" src="{% static 'img/about/petFriends.png' %}">
+        <img id="characterImg" style="width:80%;text-align: center;" src="{% static 'img/about/petFriends.png' %}">
     </div>
     <div id="characterInfo">
         <div class="infoRow">

--- a/templates/home/home.html
+++ b/templates/home/home.html
@@ -9,11 +9,11 @@
         <h1 id="mainText">반려동물을 위한<br />요리 레시피를<br />공유해봐요!</h1>
     </div>
     <img id="rabbit" src="{% static 'img/home/home_rabbit.png'%}">
-    <img class="rabbitShadow" src="{% static 'img/home/rabbitShadow.png'%}">
+    <img class="rabbitShadow" style="width:279px;left:1007px;top:360.88px;" src="{% static 'img/home/rabbitShadow.png'%}">
     <img id="cat" src="{% static 'img/home/home_cat.png'%}">
-    <img class="catShadow" src="{% static 'img/home/catShadow.png'%}">
+    <img class="catShadow" style="width:220px;left:1036px;top:798.31px;" src="{% static 'img/home/catShadow.png'%}">
     <img id="dog" src="{% static 'img/home/home_dog.png'%}">
-    <img class="dogShadow" src="{% static 'img/home/dogShadow.png'%}">
+    <img class="dogShadow" style="left:1270px;" src="{% static 'img/home/dogShadow.png'%}">
     <div>
         <form class="searchBarBox" style="width: 500px;" action="{% url 'home:search' %}" method="POST">
             {% csrf_token %}
@@ -59,7 +59,6 @@
                 </div>
                 {% endif %}
                 {% endfor %}
-            {% else %}
             {% endif %}
         </div>
     </div>

--- a/templates/recipe/recipe_list.html
+++ b/templates/recipe/recipe_list.html
@@ -11,7 +11,7 @@
     {% for item, image in hot_recipes_dict.items %}
     {% if forloop.counter < 5 %}
         {% if image %}
-        <div onclick = "location.href='{% url 'recipe:detail_recipe' recipe_id=item.id %}'" style="border-radius: 0px 0px 80px 80px; width: 100%; height: 550px; background-image: linear-gradient( rgba(0, 0, 0, 0.3), rgba(0, 0, 0, 0.3) ), url('{{ image }}'); background-size: 100%;">
+        <div onclick = "location.href='{% url 'recipe:detail_recipe' recipe_id=item.id %}'" style="border-radius: 0px 0px 80px 80px; width: 100%; height: 550px; background-image: linear-gradient( rgba(0, 0, 0, 0.3), rgba(0, 0, 0, 0.3) ), url('{{ image }}'); background-size: 100%;cursor: pointer;">
             <div style="padding: 0 7%;">
                 {% include 'nav.html' %}
             </div>
@@ -20,7 +20,7 @@
             <p class="hot_summary" style="color:white;"> {{ item.summary }}</p>
         </div>
         {% else %}
-        <div onclick = "location.href='{% url 'recipe:detail_recipe' recipe_id=item.id %}'" style="border-radius: 0px 0px 80px 80px; width: 100%; height: 550px; background: black; ">
+        <div onclick = "location.href='{% url 'recipe:detail_recipe' recipe_id=item.id %}'" style="border-radius: 0px 0px 80px 80px; width: 100%; height: 550px; background: black;cursor: pointer;">
             <div style="padding: 0 7%;">
                 {% include 'nav.html' %}
             </div>

--- a/templates/review/review_list.html
+++ b/templates/review/review_list.html
@@ -11,7 +11,7 @@
         {% for item, image in best_review_dict.items %}
         {% if forloop.counter < 5 %}
             {% if image %}
-            <div onclick="location.href='{% url 'review:detail_review' review_id=item.id %}'" style="border-radius: 0px 0px 80px 80px; width: 100%; height: 550px; background-image: linear-gradient( rgba(0, 0, 0, 0.3), rgba(0, 0, 0, 0.3) ),url('{{ image }}'); background-size: 100%;">
+            <div onclick="location.href='{% url 'review:detail_review' review_id=item.id %}'" style="border-radius: 0px 0px 80px 80px; width: 100%; height: 550px; background-image: linear-gradient( rgba(0, 0, 0, 0.3), rgba(0, 0, 0, 0.3) ),url('{{ image }}'); background-size: 100%;cursor: pointer;">
                 <div style="padding: 0 7%;">
                     {% include 'nav.html' %}
                 </div>
@@ -20,7 +20,7 @@
                 <p class="hot_summary" style="color:white;"> {{ item.content }}</p>
             </div>
             {% else %}
-            <div onclick="location.href='{% url 'review:detail_review' review_id=item.id %}'" style="border-radius: 0px 0px 80px 80px; width: 100%; height: 550px; background: black; ">
+            <div onclick="location.href='{% url 'review:detail_review' review_id=item.id %}'" style="border-radius: 0px 0px 80px 80px; width: 100%; height: 550px; background: black;cursor: pointer;">
                 <div style="padding: 0 7%;">
                     {% include 'nav.html' %}
                 </div>


### PR DESCRIPTION
## 개요
- 핫 레시피, 베스트 리뷰가 4개가 아니더라도 홈화면과 각 리스트 상단에 나타나는 에러 수정
- 소개 카테고리 css 수정
- 홈 메인박스 그림자 위치 조정
- 레시피, 리뷰 슬릭에 cursor 속성 추가

## 작업내용
- 저번에 레시피, 리뷰 목록에서 공감순 필터가 안되는 에러가 있었는데 그건 ManytoMany 필드인 like는 다르게 접근해야 한다는 것이었습니다. 그런데 핫 레시피, 베스트 리뷰에도 이게 잘못 적용되어있길래 수정했고, 그러자 홈화면과 각 리스트 상단에서의 에러가 해결되었습니다. 아마 잘못 접근된 이 recipes, review에 의해 갯수가 4개 이하여도 dict로 만드는 과정이 일어났고 템플릿에서는 해당 dict가 존재하니까 화면에 띄워준 것 같습니다. @Hongji0611 의 골칫거리가 드디어 해결되어서 기쁘군용 😊😊
- 소개 카테고리의 전반적인 요소 크기를 피그마 디자인에 맞게 더 수정했습니다. (BI 이미지, 캐릭터 소개 박스 등)
- 캐릭터 소개 내용을 `word-break: keep-all`을 이용해 더 예쁘게 줄바꿈을 하도록 변경했고 br tag를 거의 없앴습니다. (반응형으로 더 자연스럽게 잘리는 걸 pc, 모바일 모두 확인했습니다)
- 저번에 보내신 PR에서 홈 메인박스 캐릭터들의 그림자를 어바웃박스 캐릭터들의 그림자와 동일하게 css를 부여하셔서 디자인과 안 맞길래 그걸 수정했습니다.
- 레시피, 리뷰 슬릭에 `cursor:pointer`를 추가했습니다.

## 리뷰어가 확인할 사항
- 머지하시고 서버에서 pull하신 뒤에 .static_root/css/about.css에서 이번에 바뀐 코드 한줄 수정 부탁드려요!
## 기타
- 으아아 거의 다 끝났어요ㅠㅠㅠ
