### PR TITLE
Fix accept

### DIFF
--- a/question/views.py
+++ b/question/views.py
@@ -96,6 +96,9 @@ def delete_answer(request, answer_id):
     if request.user != answer.author:
         messages.error(request, '삭제 권한이 없습니다')
         return redirect('question:detail', question_id=answer.question.id)
+    elif answer.accept == True:
+        messages.error(request, '채택된 답변은 삭제가 불가능합니다.')
+        return redirect('question:detail', question_id=answer.question.id)
     else:
         answer.delete()
     return redirect('question:detail', question_id=answer.question.id)

--- a/templates/question/detailQuestion.html
+++ b/templates/question/detailQuestion.html
@@ -108,6 +108,8 @@
                             <a onclick="location.href='{% url 'account:login' %}'" style="cursor: pointer;">
                             {% elif user != question.author %}
                             <a href="#">
+                            {% elif question.accept_done %}
+                            <a href="#">
                             {% else %}
                             <a href="{% url 'question:accept' answer.id %}" class="confirm-accept" title="Accept" data-toggle="modal" data-target="#confirmModal" id="acceptButton{{answer.id}}">
                             {% endif %}


### PR DESCRIPTION
## 개요
- 채택 기능 수정

## 작업내용
- 채택된 답변은 삭제하지 못하도록 했습니다 (네이버 지식인과 동일한 시스템입니다!)
- 채택이 끝난 질문이라면 질문 작성자가 다른 글들의 채택 버튼을 눌러도 모달조차 뜨지않게 했습니다. 전에는 모달이 떴고 채택버튼을 누르면 이미 채택이 끝났다는 메시지가 나왔습니다.
- 위의 내용을 모두 로컬에서 작동확인했습니다!

## 리뷰어가 확인할 사항
- 피드백 주신 덕분에 채택 기능이 더 멋있어졌어요! 감사합니다😊👍

## 기타
- 예) 아이디어 제시, 건의사항, 위에 들어가기 애매한 내용 등
